### PR TITLE
Accomodate latest change for power-on sequence.

### DIFF
--- a/example/cr_example4_blink_power.py
+++ b/example/cr_example4_blink_power.py
@@ -7,13 +7,17 @@
 import time
 from whill import ComWHILL
 
+def power_on_callback():
+    print('WHILL wakes up')
 
 def main():
-    whill = ComWHILL(port='COM4')
+    whill = ComWHILL(port='/dev/ttyUSB0')
+    whill.register_callback('power_on', power_on_callback)
     while True:
-        time.sleep(3)
+        whill.sleep(3)
         whill.send_power_off()
-        time.sleep(3)
+
+        whill.sleep(3)
         whill.send_power_on()
 
 

--- a/script/whill.py
+++ b/script/whill.py
@@ -107,6 +107,13 @@ class ComWHILL():
                         is_refreshed = True
         return is_refreshed
 
+    def sleep(self, secs, step_sec=0.01):
+        current_sec = 0
+        while current_sec < secs:
+            self.refresh()
+            time.sleep(step_sec)
+            current_sec += step_sec
+
     def receive_data(self):
         data_length = -1
         payload = []
@@ -163,15 +170,17 @@ class ComWHILL():
 
     def send_power_on(self):
         command_bytes = [self.CommandID.SET_POWER, self.PowerCommand.ON]
+        self.send_command(command_bytes)
+        time.sleep(0.200)
         return self.send_command(command_bytes)
 
     def send_power_off(self):
         command_bytes = [self.CommandID.SET_POWER, self.PowerCommand.OFF]
         return self.send_command(command_bytes)
 
-    def set_power(self, power_state_command):
-        command_bytes = [self.CommandID.SET_POWER, power_state_command]
-        return self.send_command(command_bytes)
+#    def set_power(self, power_state_command):
+#        command_bytes = [self.CommandID.SET_POWER, power_state_command]
+#        return self.send_command(command_bytes)
 
     def set_speed_profile(self, speed_mode,
                           forward_speed_max, forward_accel, forward_decel,


### PR DESCRIPTION
# Major Change
- Add intentional repeat for sending power-on command in order to accommodate latest change of power-on sequence.

# Minor Change
- Update power-on example
- Add `sleep()` method which is an alternative for `time.sleep()`.
- Remove `set_power()` because a pair of `send_power_on()` and `send_power_off()` can replace `set_power()`